### PR TITLE
[#14] feat : 퀴즈 목록 API

### DIFF
--- a/src/main/java/team/latte/LatteIsAHorse/common/domain/UserGradeConverter.java
+++ b/src/main/java/team/latte/LatteIsAHorse/common/domain/UserGradeConverter.java
@@ -1,0 +1,14 @@
+package team.latte.LatteIsAHorse.common.domain;
+
+import team.latte.LatteIsAHorse.model.user.UserGrade;
+
+import javax.persistence.Converter;
+
+@Converter
+public class UserGradeConverter extends AbstractEnumAttributeConverter{
+    private static final String ENUM_NAME = "유저 학년";
+
+    public UserGradeConverter() {
+        super(UserGrade.class, false, ENUM_NAME);
+    }
+}

--- a/src/main/java/team/latte/LatteIsAHorse/common/util/firebase/FirebaseFileService.java
+++ b/src/main/java/team/latte/LatteIsAHorse/common/util/firebase/FirebaseFileService.java
@@ -31,6 +31,12 @@ public class FirebaseFileService implements FileService {
 
     private Storage storage;
 
+    @Value("${firebase.image.pre_uri}")
+    private String preUri;
+
+    @Value("${firebase.image.post_uri}")
+    private String postUri;
+
     @EventListener
     public void init(ApplicationReadyEvent event) {
         try {
@@ -52,7 +58,7 @@ public class FirebaseFileService implements FileService {
             imageName = uploadFile(file, fileName);                // 파일 업로드
             file.delete();                                         // 프로젝트 폴더에 저장된 업로드 파일 삭제
 
-            return imageName;
+            return preUri + imageName + postUri;
         } catch (Exception e) {
             throw new CustomException(ExceptionStatus.SERVER_ERROR);
         }
@@ -81,6 +87,7 @@ public class FirebaseFileService implements FileService {
     }
 
     public boolean deleteFile(String fileName) {
+        fileName = fileName.replace(preUri,"").replace(postUri,"");
         BlobInfo blobInfo = getBlobInfo(fileName);
         storage.delete(blobInfo.getBlobId());
         return true;

--- a/src/main/java/team/latte/LatteIsAHorse/config/response/ResponseMessage.java
+++ b/src/main/java/team/latte/LatteIsAHorse/config/response/ResponseMessage.java
@@ -17,7 +17,10 @@ public enum ResponseMessage {
     COLLEGE_AUTH_FAIL("대학 인증에 실패했습니다."),
 
     QUIZ_CREATED_SUCCESS("퀴즈 등록이 성공했습니다."),
-    QUIZ_CREATED_FAIL("퀴즈 등록이 실패했습니다.");
+    QUIZ_CREATED_FAIL("퀴즈 등록이 실패했습니다."),
+
+    QUIZ_LIST_SUCCESS("퀴즈 목록 조회가 성공했습니다."),
+    QUIZ_LIST_FAIL("퀴즈 목록 조회가 실패헀습니다.");
 
     private final String message;
 }

--- a/src/main/java/team/latte/LatteIsAHorse/controller/QuizController.java
+++ b/src/main/java/team/latte/LatteIsAHorse/controller/QuizController.java
@@ -8,12 +8,14 @@ import team.latte.LatteIsAHorse.common.util.firebase.FirebaseFileService;
 import team.latte.LatteIsAHorse.config.response.ApiResponse;
 import team.latte.LatteIsAHorse.config.response.ResponseMessage;
 import team.latte.LatteIsAHorse.config.security.authentication.CustomUserDetails;
+import team.latte.LatteIsAHorse.dto.AllQuizRes;
 import team.latte.LatteIsAHorse.dto.CreateQuizReq;
 import team.latte.LatteIsAHorse.model.quiz.Quiz;
 import team.latte.LatteIsAHorse.service.QuizService;
 import team.latte.LatteIsAHorse.service.UserService;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,5 +48,16 @@ public class QuizController {
         }
         quizService.issueLatteStack(quiz, customUserDetails.getUsername());
         return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.QUIZ_CREATED_SUCCESS);
+    }
+
+    /**
+     * 퀴즈 목록 조회
+     * @return
+     */
+    @GetMapping("/quiz")
+    public ApiResponse<Object> allQuizList() {
+        List<AllQuizRes> allQuizRes = quizService.allQuizList();
+
+        return ApiResponse.of(allQuizRes, HttpStatus.OK, ResponseMessage.QUIZ_LIST_SUCCESS);
     }
 }

--- a/src/main/java/team/latte/LatteIsAHorse/dto/AllQuizRes.java
+++ b/src/main/java/team/latte/LatteIsAHorse/dto/AllQuizRes.java
@@ -1,0 +1,51 @@
+package team.latte.LatteIsAHorse.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team.latte.LatteIsAHorse.model.quiz.Quiz;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AllQuizRes {
+
+    private Long quizId;
+
+    private String title;
+
+    private String writer;
+
+    private Long views;
+
+    private int quizLikes;
+
+    private int commentsCnt;
+
+    private String imageUrl;
+
+    private boolean isScrap;
+
+    public static AllQuizRes of(Quiz quiz) {
+        return AllQuizRes.builder()
+                .quizId(quiz.getQuizId())
+                .title(quiz.getTitle())
+                .writer(quiz.getWriter())
+                .views(quiz.getViews())
+                .quizLikes(quiz.getQuizLikes().size())
+                .commentsCnt(quiz.getComments().size())
+                .imageUrl(quiz.getImages().size() > 0 ? quiz.getImages().get(0).getUrl() : null)
+                .isScrap(quiz.getScraps().size() > 0 ? true : false)
+                .build();
+    }
+
+    public static List<AllQuizRes> listOf(List<Quiz> quizzes) {
+        return quizzes.stream().map(AllQuizRes::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/team/latte/LatteIsAHorse/dto/SignUpReq.java
+++ b/src/main/java/team/latte/LatteIsAHorse/dto/SignUpReq.java
@@ -1,6 +1,7 @@
 package team.latte.LatteIsAHorse.dto;
 
 import lombok.*;
+import team.latte.LatteIsAHorse.model.user.UserGrade;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -21,5 +22,14 @@ public class SignUpReq {
     @NotBlank
     @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&])[A-Za-z[0-9]$@$!%*#?&]{8,15}$", message = "패스워드는 8~12자리로 구성되어야합니다.")
     private String password;
+
+    @NotBlank(message = "대학교를 확인해주세요.")
+    private String college;
+
+    @NotBlank(message = "닉네임을 확인해주세요.")
+    private String nickname;
+
+    private UserGrade grade;
+
 
 }

--- a/src/main/java/team/latte/LatteIsAHorse/model/post/Post.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/post/Post.java
@@ -25,9 +25,6 @@ public class Post extends BaseTimeEntity {
     private Long postId;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
-    private List<Scrap> scraps = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostLike> postLikes = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/team/latte/LatteIsAHorse/model/post/Scrap.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/post/Scrap.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import team.latte.LatteIsAHorse.common.domain.BaseTimeEntity;
+import team.latte.LatteIsAHorse.model.quiz.Quiz;
 import team.latte.LatteIsAHorse.model.user.User;
 
 import javax.persistence.*;
@@ -25,16 +26,16 @@ public class Scrap extends BaseTimeEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post")
-    private Post post;
+    @JoinColumn(name = "quiz")
+    private Quiz quiz;
 
     public void setUser(User user) {
         this.user = user;
         user.getScraps().add(this);
     }
 
-    public void setPost(Post post) {
-        this.post = post;
-        post.getScraps().add(this);
+    public void setPost(Quiz quiz) {
+        this.quiz = quiz;
+        quiz.getScraps().add(this);
     }
 }

--- a/src/main/java/team/latte/LatteIsAHorse/model/quiz/Quiz.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/quiz/Quiz.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import team.latte.LatteIsAHorse.common.domain.BaseTimeEntity;
 import team.latte.LatteIsAHorse.model.comment.Comment;
 import team.latte.LatteIsAHorse.model.post.Image;
+import team.latte.LatteIsAHorse.model.post.Scrap;
 import team.latte.LatteIsAHorse.model.user.LatteStackInfo;
 import team.latte.LatteIsAHorse.model.user.User;
 
@@ -25,6 +26,9 @@ public class Quiz extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
     private List<QuizLike> quizLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "quiz", cascade = CascadeType.ALL)
+    private List<Scrap> scraps = new ArrayList<>();
 
     @OneToMany(mappedBy = "quiz")
     private List<LatteStackInfo> latteStackInfos = new ArrayList<>();
@@ -54,6 +58,8 @@ public class Quiz extends BaseTimeEntity {
 
     private String writer;
 
+    private Long views;
+
     public void setUser(User user) {
         this.user = user;
         user.getQuizzes().add(this);
@@ -65,5 +71,6 @@ public class Quiz extends BaseTimeEntity {
         this.title = title;
         this.answer = answer;
         this.writer = writer;
+        this.views = 0L;
     }
 }

--- a/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team.latte.LatteIsAHorse.common.domain.UserGradeConverter;
 import team.latte.LatteIsAHorse.common.domain.UserStateConverter;
 import team.latte.LatteIsAHorse.model.comment.Comment;
 import team.latte.LatteIsAHorse.model.comment.CommentLike;
@@ -75,7 +76,8 @@ public class User {
 
     private String college;
 
-    private int grade;
+    @Convert(converter = UserGradeConverter.class)
+    private UserGrade grade;
 
     private String nickname;
 
@@ -92,7 +94,7 @@ public class User {
     private UserState state;
 
     @Builder
-    public User(String email, String password, String college, int grade, String nickname, LocalDateTime lastLogin, int latteStack, String phoneNo, RoleType role, UserState state) {
+    public User(String email, String password, String college, UserGrade grade, String nickname, LocalDateTime lastLogin, int latteStack, String phoneNo, RoleType role, UserState state) {
         this.email = email;
         this.password = password;
         this.college = college;

--- a/src/main/java/team/latte/LatteIsAHorse/model/user/UserGrade.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/user/UserGrade.java
@@ -1,0 +1,43 @@
+package team.latte.LatteIsAHorse.model.user;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.extern.slf4j.Slf4j;
+import team.latte.LatteIsAHorse.common.domain.EnumCommonType;
+
+@Slf4j
+public enum UserGrade implements EnumCommonType {
+
+    FRESHMAN("1학년",1),
+    SOPHOMORE("2학년",2),
+    JUNIOR("3학년",3),
+    SENIOR("4학년",4),
+    GRADUATED("졸업생",5);
+
+    private String desc;
+    private int code;
+
+    UserGrade(String desc, int code) {
+        this.desc = desc;
+        this.code = code;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDesc() {
+        return desc;
+    }
+
+    @JsonCreator
+    public static UserGrade fromUserGrade(String val){
+        for(UserGrade userGrade : UserGrade.values()){
+            if(userGrade.getDesc().equals(val)){
+                return userGrade;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/team/latte/LatteIsAHorse/repository/QuizRepository.java
+++ b/src/main/java/team/latte/LatteIsAHorse/repository/QuizRepository.java
@@ -48,4 +48,10 @@ public class QuizRepository {
                 .where(quiz.quizId.eq(quizId))
                 .execute();
     }
+
+    public List<Quiz> findAll() {
+        return queryFactory
+                .selectFrom(quiz)
+                .fetch();
+    }
 }

--- a/src/main/java/team/latte/LatteIsAHorse/service/QuizService.java
+++ b/src/main/java/team/latte/LatteIsAHorse/service/QuizService.java
@@ -1,8 +1,10 @@
 package team.latte.LatteIsAHorse.service;
 
+import team.latte.LatteIsAHorse.dto.AllQuizRes;
 import team.latte.LatteIsAHorse.dto.CreateQuizReq;
 import team.latte.LatteIsAHorse.model.quiz.Quiz;
-import team.latte.LatteIsAHorse.model.user.User;
+
+import java.util.List;
 
 public interface QuizService {
 
@@ -13,4 +15,6 @@ public interface QuizService {
     Long deleteTempSavedQuiz(Quiz quiz);
 
     Long issueLatteStack(Quiz quiz, String userEmail);
+
+    List<AllQuizRes> allQuizList();
 }

--- a/src/main/java/team/latte/LatteIsAHorse/service/QuizServiceImpl.java
+++ b/src/main/java/team/latte/LatteIsAHorse/service/QuizServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.latte.LatteIsAHorse.dto.AllQuizRes;
 import team.latte.LatteIsAHorse.dto.CreateQuizReq;
 import team.latte.LatteIsAHorse.model.post.Image;
 import team.latte.LatteIsAHorse.model.quiz.Answer;
@@ -51,6 +52,7 @@ public class QuizServiceImpl implements QuizService {
                 .answer(createQuizReq.getAnswer())
                 .title(createQuizReq.getTitle())
                 .writer(user.getNickname())
+
                 .build();
 
         for (String answerContent : createQuizReq.getAnswers()) {
@@ -131,5 +133,15 @@ public class QuizServiceImpl implements QuizService {
         LatteStackInfo latteStackInfo = LatteStackInfo.createLatteStackInfo(quiz, user);
         LatteStackInfo savedLatteStackInfo = latteStackInfoRepository.save(latteStackInfo);
         return savedLatteStackInfo.getLatteStackInfoId();
+    }
+
+    /**
+     * 퀴즈 목록 조회
+     * @return
+     */
+    @Override
+    public List<AllQuizRes> allQuizList() {
+        List<Quiz> allQuiz = quizRepository.findAll();
+        return AllQuizRes.listOf(allQuiz);
     }
 }

--- a/src/main/java/team/latte/LatteIsAHorse/service/UserService.java
+++ b/src/main/java/team/latte/LatteIsAHorse/service/UserService.java
@@ -30,6 +30,9 @@ public class UserService {
                 .email(req.getEmail())
                 .password(passwordEncoder.encode(req.getPassword()))
                 .state(UserState.VALID)
+                .nickname(req.getNickname())
+                .college(req.getCollege())
+                .grade(req.getGrade())
                 .role(RoleType.ROLE_USER) // 임시로 USER로 해둠. 운영시에는 GUEST로 다시 바꿔야함
                 .build();
         User savedUser = userRepository.save(user);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,3 @@
+INSERT INTO USER VALUES (1, '서울대', 'seoul@naver.com', 2, '2021-11-10 18:35:21.632145', 0, '오늘저녁은치킨이닭','{bcrypt}$2a$10$qfRVPI30zDA2YAwjV2V/iONNjayz7Kf.j1Ca4Xwh/KpsPJ.p5jz1S','010-1234-5678','ROLE_USER',1);
+
+INSERT INTO QUIZ VALUES (1, '2021-11-10 19:00:00.342675', '2021-11-10 19:00:00.342675', 1, '우리학교에는 비건을 위한 식당이 있다?없다?', 0, '오늘저녁은치킨이닭', 1);

--- a/src/test/java/team/latte/LatteIsAHorse/repository/QuizRepositoryTest.java
+++ b/src/test/java/team/latte/LatteIsAHorse/repository/QuizRepositoryTest.java
@@ -101,4 +101,38 @@ class QuizRepositoryTest {
                 ()-> assertThat(QuizzesbyUser).containsAll(expectedQuizzes)
         );
     }
+
+
+    @Test
+    void findAll() {
+
+        // given
+        User user = User.builder()
+                .email("1234")
+                .state(UserState.VALID)
+                .role(RoleType.ROLE_GUEST)
+                .build();
+        userRepository.save(user);
+
+        Quiz quiz1 = Quiz.builder()
+                .user(user)
+                .build();
+
+        Quiz quiz2 = Quiz.builder()
+                .user(user)
+                .build();
+        quizRepository.save(quiz1);
+        quizRepository.save(quiz2);
+
+        // when
+        List<Quiz> quizzes = quizRepository.findAll();
+
+        // then
+        assertAll(
+                () -> Assertions.assertThat(quizzes.size()).isEqualTo(2),
+                () -> Assertions.assertThat(quizzes.get(0)).isEqualTo(quiz1),
+                () -> Assertions.assertThat(quizzes.get(1)).isEqualTo(quiz2)
+        );
+
+    }
 }


### PR DESCRIPTION
feat : 퀴즈 목록 API
- QuizController, QuizService, QuizRepository 관련 로직 추가
- AllQuizRes 추가
- (기획 변경으로 인한) post에서 scraps 삭제, 대신 quiz에 추가
- Usergrade enum 추가
- UserGradeConverter 추가
- data.sql 추가

chore : FirebaseFileService
- 저장되는 Uri를 부분이 아닌 전체 Uri로 수정

chore : 회원가입 DTO
- 대학교, 학년, 닉네임 추가