### PR TITLE
[#49] refactoring : User Email Indexing 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,26 +85,26 @@ configurations {
 }
 
 
-//
-//clean {
-//	delete file(querydslDir) // 인텔리제이 Annotation processor 생성물 생성위치
-//}
-//tasks.withType(JavaCompile) {
-//	options.generatedSourceOutputDirectory = file(querydslDir)
-//}
 
-///**
-// *  compileQuerydsl.doFirst 추가
-// */
-//compileQuerydsl.doFirst {
-//	if ( file(querydslDir).exists() )
-//		delete(file(querydslDir))
-//}
-///**
-// *  compileQuerydsl.doFirst end
-// */
+clean {
+	delete file(querydslDir) // 인텔리제이 Annotation processor 생성물 생성위치
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+/**
+ *  compileQuerydsl.doFirst 추가
+ */
+compileQuerydsl.doFirst {
+	if ( file(querydslDir).exists() )
+		delete(file(querydslDir))
+}
+/**
+ *  compileQuerydsl.doFirst end
+ */
+
 //
-////
-//clean.doLast {
-//	delete file(querydslDir)
-//}
+clean.doLast {
+	delete file(querydslDir)
+}

--- a/src/main/java/team/latte/LatteIsAHorse/config/response/ErrorResponse.java
+++ b/src/main/java/team/latte/LatteIsAHorse/config/response/ErrorResponse.java
@@ -7,8 +7,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
-import static javafx.scene.input.KeyCode.T;
-
 @Getter
 @SuperBuilder
 public class ErrorResponse extends CommonResponse {

--- a/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
@@ -1,5 +1,19 @@
 package team.latte.LatteIsAHorse.model.user;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,15 +33,11 @@ import team.latte.LatteIsAHorse.model.quiz.QuizLike;
 import team.latte.LatteIsAHorse.model.quiz.ReportSuspicion;
 import team.latte.LatteIsAHorse.model.quiz.UserAnswer;
 
-import javax.persistence.*;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(indexes = @Index(name = "i_user", columnList = "email"))
 @Entity
 public class User {
 


### PR DESCRIPTION
user email 컬럼을 조회하는 로직을 가진 API의 성능을 향상
적용된 API 목록은 아래와 같음.

- 퀴즈 등록 501ms -> 388ms
- 퀴즈 세부 조회 14ms -> 9ms
- 퀴즈 풀기 76ms -> 49ms
- 내가 만든 퀴즈 조회 78ms -> 31ms
- 라떼 포인트 내역 조회 51ms -> 27ms
- 퀴즈 북마크 조회 23ms -> 17ms
이외 5건 (각종 좋아요, 댓글/답글 생성)