### PR TITLE
[#49] refactoring : User Email Indexing 적용

### DIFF
--- a/src/main/java/team/latte/LatteIsAHorse/config/response/ErrorResponse.java
+++ b/src/main/java/team/latte/LatteIsAHorse/config/response/ErrorResponse.java
@@ -7,7 +7,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.util.List;
 
-import static javafx.scene.input.KeyCode.T;
 
 @Getter
 @SuperBuilder

--- a/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
+++ b/src/main/java/team/latte/LatteIsAHorse/model/user/User.java
@@ -28,6 +28,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(indexes = @Index(name = "i_user", columnList = "email"))
 @Entity
 public class User {
 


### PR DESCRIPTION
user email 컬럼을 조회하는 로직을 가진 API의 성능을 향상
적용된 API 목록은 아래와 같음.

- 퀴즈 등록 501ms -> 388ms
- 퀴즈 세부 조회 14ms -> 9ms
- 퀴즈 풀기 76ms -> 49ms
- 내가 만든 퀴즈 조회 78ms -> 31ms
- 라떼 포인트 내역 조회 51ms -> 27ms
- 퀴즈 북마크 조회 23ms -> 17ms
이외 5건 (각종 좋아요, 댓글/답글 생성)